### PR TITLE
Feature/log rolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the DICOM7 project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Switched Serilog file logging to a single size-rolled log per service for easier tailing and retention control
+
 ## [2.1.0] - 2025-10-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the DICOM7 project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.1] - 2025-10-14
+
 ### Changed
 
 - Switched Serilog file logging to a single size-rolled log per service for easier tailing and retention control

--- a/DICOM2ORM/Program.cs
+++ b/DICOM2ORM/Program.cs
@@ -38,6 +38,9 @@ namespace DICOM7.DICOM2ORM
             // Initialize cache system
             ProgramHelpers.InitializeCache(_config);
 
+            // Log resolved base paths for clarity on runtime locations
+            ProgramHelpers.LogBasePaths(APPLICATION_NAME);
+
             // Register handlers for shutdown events
             Console.CancelKeyPress += OnCancelKeyPress;
             AppDomain.CurrentDomain.ProcessExit += OnProcessExit;

--- a/DICOM2ORM/Properties/AssemblyInfo.cs
+++ b/DICOM2ORM/Properties/AssemblyInfo.cs
@@ -30,6 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+// [assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+

--- a/DICOM2ORU/Program.cs
+++ b/DICOM2ORU/Program.cs
@@ -39,6 +39,9 @@ namespace DICOM7.DICOM2ORU
         // Initialize cache system
         ProgramHelpers.InitializeCache(_config);
 
+        // Log resolved base paths for clarity on runtime locations
+        ProgramHelpers.LogBasePaths(APPLICATION_NAME);
+
         // Register handlers for shutdown events
         Console.CancelKeyPress += OnCancelKeyPress;
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;

--- a/DICOM2ORU/Properties/AssemblyInfo.cs
+++ b/DICOM2ORU/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -30,6 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+// [assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+

--- a/ORM2DICOM/Program.cs
+++ b/ORM2DICOM/Program.cs
@@ -38,6 +38,9 @@ namespace DICOM7.ORM2DICOM
         // Initialize cache system
         ProgramHelpers.InitializeCache(_config, logCacheFolder: true);
 
+        // Log resolved base paths for clarity on runtime locations
+        ProgramHelpers.LogBasePaths(APPLICATION_NAME);
+
         // Register handlers for shutdown events
         Console.CancelKeyPress += OnCancelKeyPress;
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;

--- a/ORM2DICOM/Properties/AssemblyInfo.cs
+++ b/ORM2DICOM/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -30,6 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+// [assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+

--- a/ORU2DICOM/Program.cs
+++ b/ORU2DICOM/Program.cs
@@ -25,14 +25,17 @@ namespace DICOM7.ORU2DICOM
       {
         _config = ProgramHelpers.LoadConfiguration<Config>(APPLICATION_NAME);
         ProgramHelpers.InitializeCache(_config, defaultRetentionDays: _config.Cache != null ? _config.Cache.RetentionDays : 3, logCacheFolder: true);
+        // Log resolved base paths for clarity on runtime locations
+        ProgramHelpers.LogBasePaths(APPLICATION_NAME);
         CacheManager.Initialize(_config.Cache);
 
         _processor = new OruMessageProcessor(_config);
         _hl7Server = new Hl7Server(_config, _processor);
-        _cts = new CancellationTokenSource();
 
         Console.CancelKeyPress += OnCancelKeyPress;
         AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+
+        _cts = new CancellationTokenSource();
 
         _hl7Server.Start();
 

--- a/ORU2DICOM/Properties/AssemblyInfo.cs
+++ b/ORU2DICOM/Properties/AssemblyInfo.cs
@@ -30,6 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+// [assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
+

--- a/Shared/Common/ProgramHelpers.cs
+++ b/Shared/Common/ProgramHelpers.cs
@@ -65,7 +65,7 @@ namespace DICOM7.Shared.Common
     /// <param name="applicationName">The name of the application for log file naming</param>
     public static void ConfigureSerilog(string applicationName)
     {
-      string logPath = Path.Combine(AppConfig.CommonAppFolder, "logs", $"dicom7-{applicationName.ToLowerInvariant()}-.log");
+      string logPath = Path.Combine(AppConfig.CommonAppFolder, "logs", $"dicom7-{applicationName.ToLowerInvariant()}.log");
       Log.Logger = new LoggerConfiguration()
 #if DEBUG
           .MinimumLevel.Debug()
@@ -74,12 +74,25 @@ namespace DICOM7.Shared.Common
 #endif
           .WriteTo.Console()
           .WriteTo.File(logPath,
-              rollingInterval: RollingInterval.Day,
               retainedFileCountLimit: 7,
               fileSizeLimitBytes: 1024 * 1024 * 10,
               rollOnFileSizeLimit: true
           )
           .CreateLogger();
+    }
+
+    /// <summary>
+    /// Logs the executing base directory and the resolved common application folder for the current service.
+    /// Helps clarify where binaries live versus writable storage.
+    /// </summary>
+    /// <param name="applicationName">The service name for contextual logging.</param>
+    public static void LogBasePaths(string applicationName)
+    {
+      string baseDirectory = AppContext.BaseDirectory ?? string.Empty;
+      string commonAppFolder = AppConfig.CommonAppFolder;
+
+      Log.Information("{ApplicationName} executable base directory: {BaseDirectory}", applicationName, baseDirectory);
+      Log.Information("{ApplicationName} common application folder: {CommonAppFolder}", applicationName, commonAppFolder);
     }
 
     /// <summary>

--- a/installer/DICOM7Setup.iss
+++ b/installer/DICOM7Setup.iss
@@ -1,7 +1,7 @@
 ; DICOM7 Inno Setup Script
 
 #define MyAppName "DICOM7"
-#define MyAppVersion "2.1.0"
+#define MyAppVersion "2.1.1"
 #define MyAppPublisher "Flux Inc"
 #define MyAppURL "https://fluxinc.co/"
 #define MyAppExeName "DICOM2ORM.exe"
@@ -124,3 +124,4 @@ function InitializeSetup(): Boolean;
 begin
   Result := True;
 end;
+

--- a/scripts/set-version.ps1
+++ b/scripts/set-version.ps1
@@ -1,0 +1,108 @@
+param(
+  [Parameter(Mandatory = $false)]
+  [ValidateSet('major', 'minor', 'patch')]
+  [string]$Bump,
+
+  [Parameter(Mandatory = $false)]
+  [string]$Version
+)
+
+if (-not $Version -and -not $Bump) {
+  throw "Specify -Bump (major|minor|patch) or provide an explicit -Version."
+}
+
+if ($Version -and $Bump) {
+  Write-Host "Ignoring -Bump because -Version was provided."
+}
+
+$scriptRoot = $PSScriptRoot
+if (-not $scriptRoot) {
+  $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+}
+$projectRoot = Split-Path -Parent $scriptRoot
+
+$installerPath = Join-Path $projectRoot "installer/DICOM7Setup.iss"
+if (-not (Test-Path $installerPath)) {
+  throw "Installer definition not found at $installerPath."
+}
+
+function Parse-Version {
+  param([string]$Value)
+
+  $pattern = '^(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?(?:\.(?<revision>\d+))?$'
+  $match = [regex]::Match($Value, $pattern)
+  if (-not $match.Success) {
+    throw "Invalid version format: $Value"
+  }
+
+  $patch = if ($match.Groups['patch'].Success) { [int]$match.Groups['patch'].Value } else { 0 }
+  $revision = if ($match.Groups['revision'].Success) { [int]$match.Groups['revision'].Value } else { 0 }
+
+  return [pscustomobject]@{
+    Major        = [int]$match.Groups['major'].Value
+    Minor        = [int]$match.Groups['minor'].Value
+    Patch        = $patch
+    Revision     = $revision
+    OriginalText = $Value
+  }
+}
+
+$currentVersionMatch = Select-String -Path $installerPath -Pattern '#define\s+MyAppVersion\s+"(?<version>[\d\.]+)"'
+if (-not $currentVersionMatch) {
+  throw "Unable to locate MyAppVersion in $installerPath."
+}
+$currentVersion = Parse-Version $currentVersionMatch.Matches[0].Groups['version'].Value
+
+if ($Version) {
+  $targetVersion = Parse-Version $Version
+} else {
+  $major = $currentVersion.Major
+  $minor = $currentVersion.Minor
+  $patch = $currentVersion.Patch
+
+  switch ($Bump) {
+    'major' { $major++; $minor = 0; $patch = 0 }
+    'minor' { $minor++; $patch = 0 }
+    'patch' { $patch++ }
+    default { throw "Unsupported bump type: $Bump" }
+  }
+
+  $targetVersion = [pscustomobject]@{
+    Major    = $major
+    Minor    = $minor
+    Patch    = $patch
+    Revision = 0
+  }
+}
+
+$productVersion = "{0}.{1}.{2}" -f $targetVersion.Major, $targetVersion.Minor, $targetVersion.Patch
+$assemblyVersion = "{0}.{1}.{2}.{3}" -f $targetVersion.Major, $targetVersion.Minor, $targetVersion.Patch, $targetVersion.Revision
+
+$assemblyFiles = @(
+  "DICOM2ORM/Properties/AssemblyInfo.cs",
+  "DICOM2ORU/Properties/AssemblyInfo.cs",
+  "ORM2DICOM/Properties/AssemblyInfo.cs",
+  "ORU2DICOM/Properties/AssemblyInfo.cs"
+) | ForEach-Object { Join-Path $projectRoot $_ }
+
+foreach ($assemblyFile in $assemblyFiles) {
+  if (-not (Test-Path $assemblyFile)) {
+    throw "AssemblyInfo not found at $assemblyFile."
+  }
+
+  $content = Get-Content -Path $assemblyFile -Raw
+  $content = [regex]::Replace($content, '\[assembly:\s*AssemblyVersion\("[^"]*"\)\]', "[assembly: AssemblyVersion(`"$assemblyVersion`")]")
+  $content = [regex]::Replace($content, '\[assembly:\s*AssemblyFileVersion\("[^"]*"\)\]', "[assembly: AssemblyFileVersion(`"$assemblyVersion`")]")
+  Set-Content -Path $assemblyFile -Value $content -Encoding UTF8
+
+  $relativePath = $assemblyFile.Replace($projectRoot + [System.IO.Path]::DirectorySeparatorChar, "")
+  Write-Host "Updated $relativePath"
+}
+
+$installerContent = Get-Content -Path $installerPath -Raw
+$installerContent = [regex]::Replace($installerContent, '#define\s+MyAppVersion\s+"[^"]+"', "#define MyAppVersion `"$productVersion`"")
+Set-Content -Path $installerPath -Value $installerContent -Encoding UTF8
+Write-Host "Updated installer/DICOM7Setup.iss"
+
+$fromVersion = "{0}.{1}.{2}" -f $currentVersion.Major, $currentVersion.Minor, $currentVersion.Patch
+Write-Host "Version bumped from $fromVersion to $productVersion (assembly: $assemblyVersion)"


### PR DESCRIPTION
This pull request introduces DICOM7 version 2.1.1, focusing on improved logging clarity and maintainability, as well as streamlining the versioning process. The primary changes include switching to a size-rolled logging strategy, adding runtime path logging for all services, and updating version numbers across the project. Additionally, a new PowerShell script is introduced to automate version updates.

**Logging improvements:**

- Switched Serilog file logging to use a single, size-rolled log file per service (removing daily rolling), simplifying log management and retention. (`Shared/Common/ProgramHelpers.cs`, `CHANGELOG.md`) [[1]](diffhunk://#diff-c20e36c966f262d59ffae04844191d8abfd720a8dd19df6299d8ca542883800aL68-R68) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R12)
- Added a new utility method `LogBasePaths` in `ProgramHelpers` and invoked it at startup for all services to log the executable base directory and application data folder, aiding in diagnostics and deployment clarity. (`Shared/Common/ProgramHelpers.cs`, `DICOM2ORM/Program.cs`, `DICOM2ORU/Program.cs`, `ORM2DICOM/Program.cs`, `ORU2DICOM/Program.cs`) [[1]](diffhunk://#diff-c20e36c966f262d59ffae04844191d8abfd720a8dd19df6299d8ca542883800aL77-R97) [[2]](diffhunk://#diff-dc75018e1c89e1db0e7cc92af37f200fca968b423b66662da84c123c7f261359R41-R43) [[3]](diffhunk://#diff-6d6abf8282419d4fe28c1a89fafab7cc1b0de3d064852cb8a6e218a0328b9ca4R42-R44) [[4]](diffhunk://#diff-f7e143407c8640bda2367ace9d5bf008b4c59165a1cb825aaf841ee97753625cR41-R43) [[5]](diffhunk://#diff-24ff67063d3227c6521d64923930d736191337b964ae94337417c3c10dd1ff2cR28-R39)

**Versioning and automation:**

- Updated all service and installer version numbers to 2.1.1 to reflect the new release. (`DICOM2ORM/Properties/AssemblyInfo.cs`, `DICOM2ORU/Properties/AssemblyInfo.cs`, `ORM2DICOM/Properties/AssemblyInfo.cs`, `ORU2DICOM/Properties/AssemblyInfo.cs`, `installer/DICOM7Setup.iss`) [[1]](diffhunk://#diff-1ff9cd3424a70fd3091b0f942797c351370e4b3eaea93389c5d68c605bc285c9L33-R36) [[2]](diffhunk://#diff-6c9152f0916410eca8670b9535063f25e0b54f399d426128da391fe212cb414bL33-R36) [[3]](diffhunk://#diff-76af2c202dd650118dc9636cfa2ca3aac642e357f691846b3f5520a7f25aea12L33-R36) [[4]](diffhunk://#diff-b0ab5dc65066de735fb5aeec94a7e38b915eb3f42d80d5adf3c000bd43191ad3L33-R36) [[5]](diffhunk://#diff-2cf3a8628d6c8f2a5edbc1ca25d7d432b1192cbdd2b736ec22ca9a9c162941a3L4-R4)
- Added a new PowerShell script `set-version.ps1` to automate bumping and synchronizing version numbers across assemblies and the installer. (`scripts/set-version.ps1`)

**Minor code tidying:**

- Fixed minor formatting and encoding issues in assembly info files and installer script. (`DICOM2ORU/Properties/AssemblyInfo.cs`, `ORM2DICOM/Properties/AssemblyInfo.cs`, `installer/DICOM7Setup.iss`) [[1]](diffhunk://#diff-6c9152f0916410eca8670b9535063f25e0b54f399d426128da391fe212cb414bL1-R1) [[2]](diffhunk://#diff-76af2c202dd650118dc9636cfa2ca3aac642e357f691846b3f5520a7f25aea12L1-R1) [[3]](diffhunk://#diff-2cf3a8628d6c8f2a5edbc1ca25d7d432b1192cbdd2b736ec22ca9a9c162941a3R127)